### PR TITLE
Reorder Queue, Process priority and Stop

### DIFF
--- a/src/ProcessManager/ProcessDataReceivedEventArgs.cs
+++ b/src/ProcessManager/ProcessDataReceivedEventArgs.cs
@@ -24,7 +24,7 @@ namespace ProcessManager
         internal ProcessDataReceivedEventArgs(ProcessInfo processInfo, string data)
             : base(processInfo)
         {
-            this.Data = data;
+            Data = data;
         }
 
         /// <summary>

--- a/src/ProcessManager/ProcessEventArgs.cs
+++ b/src/ProcessManager/ProcessEventArgs.cs
@@ -25,7 +25,7 @@ namespace ProcessManager
     {
         internal ProcessEventArgs(ProcessInfo processInfo)
         {
-            this.ProcessInfo = processInfo;
+            ProcessInfo = processInfo;
         }
 
         /// <summary>

--- a/src/ProcessManager/ProcessFailedToStartEventArgs.cs
+++ b/src/ProcessManager/ProcessFailedToStartEventArgs.cs
@@ -26,7 +26,7 @@ namespace ProcessManager
         internal ProcessFailedToStartEventArgs(ProcessInfo processInfo, Exception exception)
             : base(processInfo)
         {
-            this.Exception = exception;
+            Exception = exception;
         }
 
         /// <summary>

--- a/src/ProcessManager/ProcessInfo.cs
+++ b/src/ProcessManager/ProcessInfo.cs
@@ -30,9 +30,9 @@ namespace ProcessManager
         /// <param name="arguments">The command-line arguments for the process.</param>
         public ProcessInfo(string fileName, string arguments)
         {
-            this.Key = Guid.NewGuid();
-            this.FileName = fileName;
-            this.Arguments = arguments;
+            Key = Guid.NewGuid();
+            FileName = fileName;
+            Arguments = arguments;
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace ProcessManager
         public ProcessInfo(string fileName, string arguments, T data)
             : base(fileName, arguments)
         {
-            this.Data = data;
+            Data = data;
         }
 
         /// <summary>

--- a/src/ProcessManager/ProcessManager.csproj
+++ b/src/ProcessManager/ProcessManager.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ProcessManager</RootNamespace>
     <AssemblyName>ProcessManager</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
alex6dj/process-managerI plan to use it for a converter with ffmpeg.

Some way to reorder the process queue after it has started working. It can be with the use of priorities.

Some way to stop the queue, you can pause the queue and wait for the current processes to complete or just do a Kill ().

And finally change the priority of processes independently or as a whole so they do not interfere with the use that is given to the PC because in normal priority is difficult to work on it. Preferably change the priority of all to see instantly.